### PR TITLE
feat: Shared-secret MAC calculation

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,6 +23,11 @@ jobs:
       with:
         command: fmt
         args: -- --check
+    - name: Check all features
+      uses: actions-rs/cargo@v1
+      with:
+        command: check
+        args: --all-features
     - name: Catch common mistakes
       uses: actions-rs/cargo@v1
       with:

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -17,6 +17,11 @@ jobs:
         toolchain: stable
         profile: minimal
         override: true
+    - name: Check all features
+      uses: actions-rs/cargo@v1
+      with:
+        command: check
+        args: --all-features
     - name: Run tests
       uses: actions-rs/cargo@v1
       with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,17 @@ edition = "2018"
 [features]
 client = []
 server = []
+
+shared-secret-registration-mac = ["dep:hex", "dep:hmac", "dep:sha1"]
+
 unstable-exhaustive-types = []
 
 [dependencies]
+hex = { version = "0.4.3", optional = true }
+hmac = { version = "0.12.1", optional = true }
 ruma = { version = "0.6.4", features = ["api", "events"] }
 serde = { version = "1.0.118", features = ["derive"] }
+sha1 = { version = "0.10.1", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0.61"


### PR DESCRIPTION
I've put the whole requests behind the feature gate, as the request can't be made without the MAC at all.

Wondering, is compiling all features here part of the github workflow, since that doesn't seem to be the case? As otherwise it might break easily in the future.

Follow-up from https://github.com/matrix-org/matrix-rust-sdk/issues/929#issuecomment-1213042513