### PR TITLE
Add locked users property

### DIFF
--- a/src/users.rs
+++ b/src/users.rs
@@ -67,7 +67,7 @@ pub struct UserDetails {
     pub external_ids: Vec<ExternalId>,
 
     /// Is the account locked
-    #[serde(deserialize_with = "crate::serde::bool_or_uint")]
+    #[serde(default, deserialize_with = "crate::serde::bool_or_uint")]
     pub locked: bool,
 }
 

--- a/src/users.rs
+++ b/src/users.rs
@@ -65,6 +65,10 @@ pub struct UserDetails {
     /// A list of external auth identifiers the homeserver has associated with the user.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub external_ids: Vec<ExternalId>,
+
+    /// Is the account locked
+    #[serde(deserialize_with = "crate::serde::bool_or_uint")]
+    pub locked: bool,
 }
 
 /// An external ID associated with a user

--- a/src/users/create_or_modify/v2.rs
+++ b/src/users/create_or_modify/v2.rs
@@ -56,8 +56,9 @@ pub struct Request {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deactivated: Option<bool>,
 
-    /// Should the user be locked
-    /// defaults to false, or the current value if user already exists
+    /// Whether the user should be locked.
+    ///
+    /// Defaults to false, or the current value if user already exists.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub locked: Option<bool>,
 }

--- a/src/users/create_or_modify/v2.rs
+++ b/src/users/create_or_modify/v2.rs
@@ -55,6 +55,11 @@ pub struct Request {
     /// defaults to false, or the current value if user already exists
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deactivated: Option<bool>,
+
+    /// Should the user be locked
+    /// defaults to false, or the current value if user already exists
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub locked: Option<bool>,
 }
 
 #[response]
@@ -89,6 +94,7 @@ impl Request {
             avatar_url: None,
             admin: None,
             deactivated: None,
+            locked: None,
         }
     }
 }

--- a/src/users/list_users/v2.rs
+++ b/src/users/list_users/v2.rs
@@ -56,6 +56,13 @@ pub struct Request {
     #[serde(default, skip_serializing_if = "ruma::serde::is_default")]
     #[ruma_api(query)]
     pub deactivated: bool,
+
+    /// The parameter locked is optional and if true will include locked users.
+    ///
+    /// Defaults to false to exclude locked users.
+    #[serde(default, skip_serializing_if = "ruma::serde::is_default")]
+    #[ruma_api(query)]
+    pub locked: bool,
 }
 
 #[response]
@@ -116,4 +123,8 @@ pub struct UserMinorDetails {
     /// The user's avatar URL, if set.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub avatar_url: Option<String>,
+
+    /// Is the account locked
+    #[serde(deserialize_with = "crate::serde::bool_or_uint")]
+    pub locked: bool,
 }

--- a/src/users/list_users/v2.rs
+++ b/src/users/list_users/v2.rs
@@ -57,7 +57,7 @@ pub struct Request {
     #[ruma_api(query)]
     pub deactivated: bool,
 
-    /// The parameter locked is optional and if true will include locked users.
+    /// Whether to include locked users in the response.
     ///
     /// Defaults to false to exclude locked users.
     #[serde(default, skip_serializing_if = "ruma::serde::is_default")]
@@ -124,7 +124,7 @@ pub struct UserMinorDetails {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub avatar_url: Option<String>,
 
-    /// Is the account locked
+    /// Whether the account is locked.
     #[serde(deserialize_with = "crate::serde::bool_or_uint")]
     pub locked: bool,
 }

--- a/src/users/list_users/v2.rs
+++ b/src/users/list_users/v2.rs
@@ -125,6 +125,6 @@ pub struct UserMinorDetails {
     pub avatar_url: Option<String>,
 
     /// Whether the account is locked.
-    #[serde(deserialize_with = "crate::serde::bool_or_uint")]
+    #[serde(default, deserialize_with = "crate::serde::bool_or_uint")]
     pub locked: bool,
 }


### PR DESCRIPTION
[Account locking](https://github.com/matrix-org/matrix-spec-proposals/pull/3939) in creation or modifying (https://github.com/matrix-org/matrix-spec-proposals/pull/3939) has been introduced in Synapse  [v1.91.0](https://github.com/matrix-org/synapse/releases/tag/v1.91.0). Admin-API list users with locked property was introduced in [v1.93.0rc1](https://github.com/matrix-org/synapse/releases/tag/v1.93.0rc1). 

In this PR:
- Added locked property in the body request to modify or create a user. 
- Added locked property in the response of retrieving users/user. 
- Added locked as filter parameter in listing users. 
