### PR TITLE
fix: update server version endpoint with optional python version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Upgrade ruma dependency to 0.7.2
 * Work around a Synapse issue affecting sqlite configurations
+* Update v1/server_version endpoint response data with optional python_version key
 
 # 0.4.0
 

--- a/src/version/get_server_version/v1.rs
+++ b/src/version/get_server_version/v1.rs
@@ -1,6 +1,7 @@
-//! [GET /_synapse/admin/v1/server_version](https://github.com/matrix-org/synapse/blob/master/docs/admin_api/version_api.rst)
+//! [GET /_synapse/admin/v1/server_version](https://github.com/element-hq/synapse/blob/master/docs/admin_api/version_api.md)
 
 use ruma::api::{metadata, request, response, Metadata};
+use serde::{Deserialize, Serialize};
 
 const METADATA: Metadata = metadata! {
     method: GET,
@@ -16,12 +17,15 @@ const METADATA: Metadata = metadata! {
 pub struct Request {}
 
 #[response]
+#[derive(Serialize, Deserialize)]
 pub struct Response {
     /// The Synapse version.
     pub server_version: String,
 
     /// The Python version.
-    pub python_version: String,
+    /// Optional since Synapse 1.94.0
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub python_version: Option<String>,
 }
 
 impl Request {
@@ -33,7 +37,51 @@ impl Request {
 
 impl Response {
     /// Creates a `Response` with the given Synapse and Python versions.
-    pub fn new(server_version: String, python_version: String) -> Self {
+    pub fn new(server_version: String, python_version: Option<String>) -> Self {
         Self { server_version, python_version }
     }
+}
+
+#[test]
+fn test_response_with_python_version() {
+    use serde_json;
+
+    let server_version = "1.2.3".to_string();
+    let python_version = Some("4.5.6".to_string());
+
+    // create response case
+    let response = Response::new(server_version.clone(), python_version.clone());
+    assert_eq!(response.server_version, server_version);
+    assert_eq!(response.python_version, python_version);
+
+    // serialization case
+    let serialized = serde_json::to_string(&response).unwrap();
+    assert_eq!(serialized, "{\"server_version\":\"1.2.3\",\"python_version\":\"4.5.6\"}");
+
+    // deserialization case
+    let deserialized: Response = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(deserialized.server_version, "1.2.3");
+    assert_eq!(deserialized.python_version, Some("4.5.6".to_string()));
+}
+
+#[test]
+fn test_response_without_python_version() {
+    use serde_json;
+
+    let server_version = "1.2.3".to_string();
+    let python_version = None;
+
+    // create response case
+    let response = Response::new(server_version.clone(), python_version);
+    assert_eq!(response.server_version, server_version);
+    assert!(response.python_version.is_none());
+
+    // serialization case
+    let serialized = serde_json::to_string(&response).unwrap();
+    assert_eq!(serialized, "{\"server_version\":\"1.2.3\"}");
+
+    // deserialization case
+    let deserialized: Response = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(deserialized.server_version, "1.2.3");
+    assert!(deserialized.python_version.is_none());
 }

--- a/src/version/get_server_version/v1.rs
+++ b/src/version/get_server_version/v1.rs
@@ -23,7 +23,8 @@ pub struct Response {
     pub server_version: String,
 
     /// The Python version.
-    /// Optional since Synapse 1.94.0
+    ///
+    /// Only sent by Synapse versions before 1.94.0.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub python_version: Option<String>,
 }

--- a/src/version/get_server_version/v1.rs
+++ b/src/version/get_server_version/v1.rs
@@ -37,9 +37,9 @@ impl Request {
 }
 
 impl Response {
-    /// Creates a `Response` with the given Synapse and Python versions.
-    pub fn new(server_version: String, python_version: Option<String>) -> Self {
-        Self { server_version, python_version }
+    /// Creates a `Response` with the given Synapse versions.
+    pub fn new(server_version: String) -> Self {
+        Self { server_version, python_version: None }
     }
 }
 
@@ -48,41 +48,24 @@ fn test_response_with_python_version() {
     use serde_json;
 
     let server_version = "1.2.3".to_string();
-    let python_version = Some("4.5.6".to_string());
 
-    // create response case
-    let response = Response::new(server_version.clone(), python_version.clone());
+    // Check create response case
+    let response = Response::new(server_version.clone());
     assert_eq!(response.server_version, server_version);
-    assert_eq!(response.python_version, python_version);
+    assert_eq!(response.python_version, None);
 
-    // serialization case
-    let serialized = serde_json::to_string(&response).unwrap();
-    assert_eq!(serialized, "{\"server_version\":\"1.2.3\",\"python_version\":\"4.5.6\"}");
-
-    // deserialization case
-    let deserialized: Response = serde_json::from_str(&serialized).unwrap();
-    assert_eq!(deserialized.server_version, "1.2.3");
-    assert_eq!(deserialized.python_version, Some("4.5.6".to_string()));
-}
-
-#[test]
-fn test_response_without_python_version() {
-    use serde_json;
-
-    let server_version = "1.2.3".to_string();
-    let python_version = None;
-
-    // create response case
-    let response = Response::new(server_version.clone(), python_version);
-    assert_eq!(response.server_version, server_version);
-    assert!(response.python_version.is_none());
-
-    // serialization case
+    // Check serialization case
     let serialized = serde_json::to_string(&response).unwrap();
     assert_eq!(serialized, "{\"server_version\":\"1.2.3\"}");
 
-    // deserialization case
+    // Check deserialization case
     let deserialized: Response = serde_json::from_str(&serialized).unwrap();
     assert_eq!(deserialized.server_version, "1.2.3");
-    assert!(deserialized.python_version.is_none());
+    assert_eq!(deserialized.python_version, None);
+
+    // Check backwards compatibility
+    let old_serialized = "{\"server_version\":\"1.2.3\",\"python_version\":\"4.5.6\"}".to_string();
+    let old_deserialized: Response = serde_json::from_str(&old_serialized).unwrap();
+    assert_eq!(old_deserialized.server_version, "1.2.3");
+    assert_eq!(old_deserialized.python_version, Some("4.5.6".to_string()));
 }


### PR DESCRIPTION
As mentioned in the docs of [admin api](https://github.com/element-hq/synapse/blob/develop/docs/admin_api/version_api.md), the python_version is no longer part of the response since 1.94.0.

- Updated docs link
- Made python_version optional
- Added tests

Signed off: @hanadi92 