### PR TITLE
List rooms improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # [unreleased]
 
+Breaking changes:
+
+* The list_room response changes the fields `version`, `join_rules`, `guest_access` and `history_visibility` to be an option
+* The list_room response changes the `join_rules` field to be `Option<SpaceRoomJoinRule>`
+
+Improvement:
+
+* The list_room response now includes the `room_type` field
+
+
 # 0.7.0
 
 * Upgrade to ruma 0.12.0

--- a/src/rooms/list_rooms/v1.rs
+++ b/src/rooms/list_rooms/v1.rs
@@ -2,6 +2,7 @@
 use ruma::{
     api::{metadata, request, response, Metadata},
     events::room::{guest_access::GuestAccess, history_visibility::HistoryVisibility},
+    room::RoomType,
     serde::StringEnum,
     space::SpaceRoomJoinRule,
     OwnedRoomAliasId, OwnedRoomId, OwnedUserId, UInt,
@@ -161,7 +162,7 @@ pub struct RoomDetails {
     pub joined_local_members: UInt,
 
     /// Room version
-    pub version: String,
+    pub version: Option<String>,
 
     /// User ID of the room creator.
     #[serde(deserialize_with = "ruma::serde::empty_string_as_none")]
@@ -189,4 +190,7 @@ pub struct RoomDetails {
 
     /// State events of the room.
     pub state_events: UInt,
+
+    /// Room type of the room.
+    pub room_type: Option<RoomType>,
 }

--- a/src/rooms/list_rooms/v1.rs
+++ b/src/rooms/list_rooms/v1.rs
@@ -1,10 +1,9 @@
-//! [GET /_synapse/admin/v1/rooms](https://github.com/matrix-org/synapse/blob/master/docs/admin_api/rooms.md#list-room-api)
+//! [GET /_synapse/admin/v1/rooms](https://github.com/element-hq/synapse/blob/master/docs/admin_api/rooms.md#list-room-api)
 use ruma::{
     api::{metadata, request, response, Metadata},
-    events::room::{
-        guest_access::GuestAccess, history_visibility::HistoryVisibility, join_rules::JoinRule,
-    },
+    events::room::{guest_access::GuestAccess, history_visibility::HistoryVisibility},
     serde::StringEnum,
+    space::SpaceRoomJoinRule,
     OwnedRoomAliasId, OwnedRoomId, OwnedUserId, UInt,
 };
 use serde::{Deserialize, Serialize};
@@ -180,13 +179,13 @@ pub struct RoomDetails {
     pub public: bool,
 
     /// Join rules of the room.
-    pub join_rules: JoinRule,
+    pub join_rules: Option<SpaceRoomJoinRule>,
 
     /// Guest access of the room
-    pub guest_access: GuestAccess,
+    pub guest_access: Option<GuestAccess>,
 
     /// History visibility of the room
-    pub history_visibility: HistoryVisibility,
+    pub history_visibility: Option<HistoryVisibility>,
 
     /// State events of the room.
     pub state_events: UInt,


### PR DESCRIPTION
I noticed that the fields, `join_rules`, `guest_access` and `history_visibility` can be null. So I wrapped them in an option.
The `join_rules` deserialization did not work with the old type.

I also added the missing `room_type` field.