### PR TITLE
fix: Third party identifiers parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Breaking changes:
   `RoomDetails` and `UserMinorDetails` are now non-exhaustive. To keep using
   them as if they were exhaustive, use the `ruma_unstable_exhaustive_types`
   compile-time `cfg` setting.
+* Changed `users::create_or_modify::v2` third party id parsing by adding a new type without `validated_at` and `added_at` fields (which are not sent according to the API documentation)
 
 Improvement:
 

--- a/src/users/create_or_modify/v2.rs
+++ b/src/users/create_or_modify/v2.rs
@@ -2,9 +2,10 @@
 
 use ruma::{
     api::{metadata, request, response, Metadata},
-    thirdparty::ThirdPartyIdentifier,
+    thirdparty::Medium,
     OwnedUserId,
 };
+use serde::{Deserialize, Serialize};
 
 pub use crate::users::{ExternalId, UserDetails};
 
@@ -105,4 +106,15 @@ impl Response {
     pub fn new(details: UserDetails) -> Self {
         Self { details }
     }
+}
+
+/// An identifier external to Matrix.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+pub struct ThirdPartyIdentifier {
+    /// The third party identifier address.
+    pub address: String,
+
+    /// The medium of third party identifier.
+    pub medium: Medium,
 }


### PR DESCRIPTION
Current version requires that third party ids contains the fields `validated_at` and `added_at`, but Synapse admin API documentation does not list those fields for `create_or_modify` endpoint: https://element-hq.github.io/synapse/latest/admin_api/user_admin_api.html#create-or-modify-account

Since those fields are currently required, the endpoint may fail to deserialize legitimate requests which do not send the mentioned fields.