### PR TITLE
Upgrade to edition 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://ruma.dev/"
 keywords = ["matrix", "chat", "messaging", "ruma"]
 license = "MIT"
 repository = "https://github.com/ruma/synapse-admin-api"
-edition = "2018"
+edition = "2021"
 rust-version = "1.82"
 
 [features]


### PR DESCRIPTION
Given the MSRV is high enough for this edition, and it's the only ruma crate not on this edition yet (I believe).